### PR TITLE
Added support for "TrustedCerts".

### DIFF
--- a/pal/inc/sslClient_arduino.h
+++ b/pal/inc/sslClient_arduino.h
@@ -17,7 +17,7 @@ extern "C" {
 
 MOCKABLE_FUNCTION(, void, sslClient_setTimeout, unsigned long, timeout);
 MOCKABLE_FUNCTION(, uint8_t, sslClient_connected);
-MOCKABLE_FUNCTION(, int, sslClient_connect, uint32_t, ipAddress, uint16_t, port);
+MOCKABLE_FUNCTION(, int, sslClient_connect, const char*, host, uint16_t, port);
 MOCKABLE_FUNCTION(, void, sslClient_stop);
 MOCKABLE_FUNCTION(, size_t, sslClient_write, const uint8_t*, buf, size_t, size);
 MOCKABLE_FUNCTION(, size_t, sslClient_print, const char*, str);
@@ -25,6 +25,8 @@ MOCKABLE_FUNCTION(, int, sslClient_read, uint8_t*, buf, size_t, size);
 MOCKABLE_FUNCTION(, int, sslClient_available);
 
 MOCKABLE_FUNCTION(, uint8_t, sslClient_hostByName, const char*, hostName, uint32_t*, ipAddress);
+
+MOCKABLE_FUNCTION(, void, sslClient_setCACert, const char*, rootCA);
 
 #ifdef __cplusplus
 }

--- a/pal/src/sslClient_arduino.cpp
+++ b/pal/src/sslClient_arduino.cpp
@@ -29,10 +29,9 @@ uint8_t sslClient_connected(void)
     return (uint8_t)sslClient.connected();
 }
 
-int sslClient_connect(uint32_t ipAddress, uint16_t port)
+int sslClient_connect(const char *host, uint16_t port)
 {
-    IPAddress ip = IPAddress(ipAddress);
-    return (int)sslClient.connect(ip, port);
+    return (int)sslClient.connect(host, port);
 }
 
 void sslClient_stop(void)
@@ -68,3 +67,7 @@ uint8_t sslClient_hostByName(const char* hostName, uint32_t* ipAddress)
     return result;
 }
 
+void sslClient_setCACert(const char *rootCA) 
+{
+    sslClient.setCACert(rootCA);
+}

--- a/pal/src/tlsio_arduino.c
+++ b/pal/src/tlsio_arduino.c
@@ -221,7 +221,7 @@ static CONCRETE_IO_HANDLE tlsio_arduino_create(void* io_create_parameters)
                     result->tlsio_state = TLSIO_STATE_CLOSED;
                     result->hostname = NULL;
                     result->pending_transmission_list = NULL;
-                    tlsio_options_initialize(&result->options, TLSIO_OPTION_BIT_NONE);
+                    tlsio_options_initialize(&result->options, TLSIO_OPTION_BIT_TRUSTED_CERTS);
                     /* Codes_SRS_TLSIO_30_016: [ tlsio_create shall make a copy of the hostname member of io_create_parameters to allow deletion of hostname immediately after the call. ]*/
                     if (NULL == (result->hostname = STRING_construct(tls_io_config->hostname)))
                     {
@@ -483,7 +483,12 @@ static void dowork_poll_socket(TLS_IO_INSTANCE* tls_io_instance)
 
 static void dowork_poll_open_ssl(TLS_IO_INSTANCE* tls_io_instance)
 {
-    if (sslClient_connect(tls_io_instance->remote_addr, tls_io_instance->port))
+    if (tls_io_instance->options.trusted_certs != NULL) 
+    {
+        sslClient_setCACert(tls_io_instance->options.trusted_certs);
+    }
+
+    if (sslClient_connect(STRING_c_str(tls_io_instance->hostname), tls_io_instance->port))
     {
         /* Codes_SRS_TLSIO_30_080: [ The tlsio_dowork shall establish a TLS connection using the hostName and port provided during tlsio_open. ]*/
         // Connect succeeded


### PR DESCRIPTION
This pull request allows users to set TrustedCerts via:
`IoTHubClient_LL_SetOption(iotHubClientHandle, "TrustedCerts", certificates);`