### PR TITLE
Do not free up tls_io_instance on DNS resolution failure.

### DIFF
--- a/pal/src/tlsio_arduino.c
+++ b/pal/src/tlsio_arduino.c
@@ -486,10 +486,7 @@ static void dowork_poll_dns(TLS_IO_INSTANCE* tls_io_instance)
     }
     else
     {
-        /* Codes_SRS_TLSIO_ARDUINO_21_019: [ If the WiFi cannot find the IP for the hostName, the tlsio_arduino_create shall destroy the sslClient and tlsio instances and return NULL as the handle. ]*/
         LogError("Host %s not found", STRING_c_str(tls_io_instance->hostname));
-        free(tls_io_instance);
-        tls_io_instance = NULL;
     }
 }
 


### PR DESCRIPTION
When the IOT Hub hostname cannot be resolved, the `tls_io_instance` is released from memory. When the SDK performs a connection retry, the `tls_io_instance` does not appear to be recreated. As a result, the address of the hostname is an invalid pointer and causes the Arduino to crash. This has been discussed in #12. 

This PR appears to fix the problem, but I am unsure whether there are any unintended side effects.

Note: I have been unable to run the tests, so some tests may be broken by this PR.