### PR TITLE
Option to automate ESP8266/ESP32 board setup for AzureIoTHub Arduino

### DIFF
--- a/build_all/base-libraries/AzureIoTHub/README.md
+++ b/build_all/base-libraries/AzureIoTHub/README.md
@@ -64,7 +64,12 @@ You should have the following ready before beginning with any board:
 
 4. Update IoT Hub Connection string in `iot_configs.h`
 
-5. Navigate to where your esp8266 board package is located, typically in `C:\Users\<your username>\AppData\Local\Arduino15\packages` on Windows and `~/.arduino15/packages/` on Linux
+5. Configure board library using the automation script and `python3`. If you choose this method you can skip step 6.
+    - Clone this repo `git clone https://github.com/Azure/azure-iot-arduino.git` or download the script [directly](https://raw.githubusercontent.com/Azure/azure-iot-arduino/master/scripts/automate_board_config.py).
+    - Run the script E.x.: `python3 automate_board_config.py` and select appropriate options.
+    - Note: if you update or reinstall your board library in Arduino you will need to run this script again.
+
+6. Navigate to where your esp8266 board package is located, typically in `C:\Users\<your username>\AppData\Local\Arduino15\packages` on Windows and `~/.arduino15/packages/` on Linux
 	
 - Locate the board's `Arduino.h` (`hardware/esp8266/<board package version>/cores/esp8266/` and comment out the line containing `#define round(x)`, around line 137.
 
@@ -76,11 +81,11 @@ You should have the following ready before beginning with any board:
 	
 	- Note3: Due to RAM limits, you must select just one CERT define.
 
-6. Run the sample.
+7. Run the sample.
 	
-7. Access the [SparkFun Get Started](https://azure.microsoft.com/en-us/documentation/samples/iot-hub-c-thingdev-getstartedkit/) tutorial to learn more about Microsoft Sparkfun Dev Kit.
+8. Access the [SparkFun Get Started](https://azure.microsoft.com/en-us/documentation/samples/iot-hub-c-thingdev-getstartedkit/) tutorial to learn more about Microsoft Sparkfun Dev Kit.
 
-8. Access the [Huzzah Get Started](https://azure.microsoft.com/en-us/documentation/samples/iot-hub-c-huzzah-getstartedkit/) tutorial to learn more about Microsoft Huzzah Dev Kit.
+9. Access the [Huzzah Get Started](https://azure.microsoft.com/en-us/documentation/samples/iot-hub-c-huzzah-getstartedkit/) tutorial to learn more about Microsoft Huzzah Dev Kit.
 
 ## ESP32
 
@@ -104,7 +109,12 @@ You should have the following ready before beginning with any board:
 
 4. Update IoT Hub Connection string in `iot_configs.h`
 
-5. Navigate to where your esp32 board package is located, typically in `C:\Users\<your username>\AppData\Local\Arduino15\packages` on Windows and `~/.arduino15/packages/` on Linux
+5. Configure board library using the automation script and `python3`. If you choose this method you can skip step 6.
+    - Clone this repo `git clone https://github.com/Azure/azure-iot-arduino.git` or download the script [directly](https://raw.githubusercontent.com/Azure/azure-iot-arduino/master/scripts/automate_board_config.py).
+    - Run the script E.x.: `python3 automate_board_config.py` and select appropriate options.
+    - Note: if you update or reinstall your board library in Arduino you will need to run this script again.
+
+6. Navigate to where your esp32 board package is located, typically in `C:\Users\<your username>\AppData\Local\Arduino15\packages` on Windows and `~/.arduino15/packages/` on Linux
 
 	- Navigate deeper in to `hardware/esp8266/<board package version>/` where the `platform.txt` file lives.
 	
@@ -112,11 +122,11 @@ You should have the following ready before beginning with any board:
 	
 	- Alternatively, or for later versions of the Board Package, add the define `-DDONT_USE_UPLOADTOBLOB` to `build.extra_flags=` in `platform.txt` or a `platform.local.txt` that you create.
 	
-6. Run the sample.
+7. Run the sample.
 	
-7. Access the [SparkFun Get Started](https://azure.microsoft.com/en-us/documentation/samples/iot-hub-c-thingdev-getstartedkit/) tutorial to learn more about Microsoft Sparkfun Dev Kit.
+8. Access the [SparkFun Get Started](https://azure.microsoft.com/en-us/documentation/samples/iot-hub-c-thingdev-getstartedkit/) tutorial to learn more about Microsoft Sparkfun Dev Kit.
 
-8. Access the [Huzzah Get Started](https://azure.microsoft.com/en-us/documentation/samples/iot-hub-c-huzzah-getstartedkit/) tutorial to learn more about Microsoft Huzzah Dev Kit.
+9. Access the [Huzzah Get Started](https://azure.microsoft.com/en-us/documentation/samples/iot-hub-c-huzzah-getstartedkit/) tutorial to learn more about Microsoft Huzzah Dev Kit.
 
 ## License
 

--- a/build_all/base-libraries/AzureIoTHub/README.md
+++ b/build_all/base-libraries/AzureIoTHub/README.md
@@ -65,7 +65,7 @@ You should have the following ready before beginning with any board:
 4. Update IoT Hub Connection string in `iot_configs.h`
 
 5. Configure board library using the automation script and `python3`. If you choose this method you can skip step 6.
-    - Clone this repo `git clone https://github.com/Azure/azure-iot-arduino.git` or download the script [directly](https://raw.githubusercontent.com/Azure/azure-iot-arduino/master/scripts/automate_board_config.py).
+    - Clone or download this repo: `git clone https://github.com/Azure/azure-iot-pal-arduino.git` , navigate to the downloaded sub-folder: `cd azure-iot-pal-arduino/build_all/base-libraries/AzureIoTHub/src/scripts` , and check that the script `automate_board_config.py` exists in this location. If this folder or script cannot be located, download the script [directly](https://raw.githubusercontent.com/Azure/azure-iot-pal-arduino/master/build_all/base-libraries/AzureIoTHub/src/scripts/automate_board_config.py).
     - Run the script E.x.: `python3 automate_board_config.py` and select appropriate options.
     - Note: if you update or reinstall your board library in Arduino you will need to run this script again.
 
@@ -110,7 +110,7 @@ You should have the following ready before beginning with any board:
 4. Update IoT Hub Connection string in `iot_configs.h`
 
 5. Configure board library using the automation script and `python3`. If you choose this method you can skip step 6.
-    - Clone this repo `git clone https://github.com/Azure/azure-iot-arduino.git` or download the script [directly](https://raw.githubusercontent.com/Azure/azure-iot-arduino/master/scripts/automate_board_config.py).
+    - Clone or download this repo: `git clone https://github.com/Azure/azure-iot-pal-arduino.git` , navigate to the downloaded sub-folder: `cd azure-iot-pal-arduino/build_all/base-libraries/AzureIoTHub/src/scripts` , and check that the script `automate_board_config.py` exists in this location. If this folder or script cannot be located, download the script [directly](https://raw.githubusercontent.com/Azure/azure-iot-pal-arduino/master/build_all/base-libraries/AzureIoTHub/src/scripts/automate_board_config.py).
     - Run the script E.x.: `python3 automate_board_config.py` and select appropriate options.
     - Note: if you update or reinstall your board library in Arduino you will need to run this script again.
 

--- a/build_all/base-libraries/AzureIoTHub/src/scripts/automate_board_config.py
+++ b/build_all/base-libraries/AzureIoTHub/src/scripts/automate_board_config.py
@@ -1,0 +1,200 @@
+from pathlib import Path
+import os
+import sys
+import fileinput
+from shutil import copyfile
+
+ESP8266_PACKAGE_PATH = Path("packages/esp8266/hardware/esp8266/")
+ESP32_PACKAGE_PATH = Path("packages/esp32/hardware/esp32/")
+
+
+def update_line_file(
+        file_path, str_line_to_update, str_append, comment_only=False,
+        comment_str=None):
+    '''
+    Updates a line on a file with a replacement (preserving the original line)
+    or comments it out
+
+    :param file_path: The path to the file
+    :type file_path: str
+    :param str_to_update: The string which will be replaced
+    :type str_line_to_update str:
+    :param str_append: The string which replace the line of str_to_update
+    :type str_append str:
+    :param comment_only: Determines whether to replace or only comment out a
+    line
+    :type comment_only boolean:
+    :param comment_str: Str to use for a comment if commenting
+    :type comment_str str:
+    :raises: :class:`FileNotFound`: File couldn't be opened
+
+    :returns: whether the string was replaced in the file or it was commented
+    out
+    :rtype: boolean
+    '''
+    file_modified = False
+    for line in fileinput.input(file_path, inplace=True):
+        if line.startswith(str_line_to_update):
+            if comment_only:
+                line = f"{comment_str} {line}"
+                file_modified = True
+            else:
+                line = line.rstrip()
+                line = f"{line}{str_append}\n"
+                file_modified = True
+        sys.stdout.write(line)
+    return file_modified
+
+
+def confirm_overwrite(file_path):
+    '''
+    Confirms whether to overwrite changes otherwise exits program
+
+    :param file_path: The path to the file
+    :type file_path: str
+    '''
+    prompt = f"There is already a backup file at" \
+             f" {file_path}; proceeding will" \
+             f" overwrite this file. Do you wish to proceed?" \
+             f" Input Y or N:" \
+             f" "
+    while True:
+        response = input(prompt)
+        response = response.lower()
+        if response == 'n':
+            print("No changes made... exiting")
+            sys.exit()
+        elif response == 'y':
+            print("Backup will be overwritten")
+            break
+        else:
+            print("Ensure your response is a Y or N")
+
+
+def main():
+    disclaimer_prompt = \
+        "This script will attempt to automatically update" \
+        " your ESP8266 and/or ESP32 board files to work with Azure IoT Hub" \
+        " for the repo https://github.com/Azure/azure-iot-arduino" \
+        "\nPlease refer to the license agreement there." \
+        "\nThis script will update all installed versions of board" \
+        " libraries for ESP8266 and/or ESP32." \
+        "\nDo you wish to proceed? Please answer Y or N:" \
+        " "
+
+    while True:
+        response = input(disclaimer_prompt)
+        response = response.lower()
+        if response == 'n':
+            print("No changes made... exiting")
+            sys.exit()
+        elif response == 'y':
+            print("Proceeding")
+            break
+        else:
+            print("Ensure your response is a Y or N")
+
+    board_prompt = \
+        "Would you like to update your ESP8266 or ESP32 board files?\n" \
+        "For ESP8266 please respond: 8266\n" \
+        "For ESP32 please respond: 32\n" \
+        "Which board files would you like to update:" \
+        " "
+
+    board_to_update = ""
+    PACKAGE_PATH = ""
+    while True:
+        response = input(board_prompt)
+        response = response.lower()
+        if response == '8266':
+            board_to_update = '8266'
+            PACKAGE_PATH = ESP8266_PACKAGE_PATH
+            break
+        elif response == '32':
+            board_to_update = '32'
+            PACKAGE_PATH = ESP32_PACKAGE_PATH
+            break
+        else:
+            print("Ensure your response is either 8226 or 32")
+
+    if sys.platform == "darwin":
+        ARDUINO_PACKAGES_PATH = Path(Path.home() / "Library/Arduino15")
+    elif sys.platform == "linux":
+        ARDUINO_PACKAGES_PATH = Path(Path.home() / ".arduino15/packages/")
+    elif sys.platform == "win32":
+        ARDUINO_PACKAGES_PATH = Path(Path.home() / "AppData/Local/Arduino15")
+    else:
+        print(f"Error: no valid board path condition for platform:"
+              f" {sys.platform}")
+        sys.exit()
+
+    print(f"Arduino path for platform {sys.platform} is:"
+          f" {ARDUINO_PACKAGES_PATH}")
+
+    # Check for and change other versions if they exist
+    try:
+        versions = []
+        with os.scandir(
+                ARDUINO_PACKAGES_PATH / PACKAGE_PATH) as entries:
+            for version in entries:
+                # avoid files and hidden files
+                if version.is_dir and not version.name.startswith('.'):
+                    versions.append(
+                        Path(
+                            ARDUINO_PACKAGES_PATH /
+                            PACKAGE_PATH / version))
+    except FileNotFoundError:
+        print(
+            f'Error: Board files for ESP{board_to_update} not found!\n'
+            f'Please ensure that the board library is installed')
+        sys.exit(1)
+
+    for path in versions:
+        if PACKAGE_PATH == ESP8266_PACKAGE_PATH:
+            # 8266 has specific files which 32 aren't required to change
+            arduino_header_backup = Path(path / "cores/esp8266/Arduino.h.orig")
+            if arduino_header_backup.exists():
+                confirm_overwrite(arduino_header_backup)
+            arduino_header_file = Path(path / "cores/esp8266/Arduino.h")
+            if arduino_header_file.exists():
+                print(f"Updating: {arduino_header_file}")
+                copyfile(
+                    arduino_header_file,
+                    Path(path / "cores/esp8266/Arduino.h.orig"))
+                print(
+                    f"Backup created:"
+                    f" {Path(path / 'cores/esp8266/Arduino.h.orig')}")
+                get_update = update_line_file(
+                    arduino_header_file, "#define round(x)",
+                    str_append=None, comment_only=True,
+                    comment_str="//")
+                print(f"Updated: {get_update} for {arduino_header_file}")
+            else:
+                print(f"Could not find {arduino_header_file}")
+                sys.exit(1)
+
+        platform_txt_backup = Path(path / "platform.txt.orig")
+        if platform_txt_backup.exists():
+            confirm_overwrite(platform_txt_backup)
+        platform_txt_file = Path(path / "platform.txt")
+        if platform_txt_file.exists():
+            print(f"Updating: {platform_txt_file}")
+            copyfile(platform_txt_file, Path(path / "platform.txt.orig"))
+            print(f"Backup created: {Path(path / 'platform.txt.orig')}")
+            append_str = ""
+            if PACKAGE_PATH == ESP8266_PACKAGE_PATH:
+                # Ensure to include spaces for flags
+                append_str = " -DDONT_USE_UPLOADTOBLOB" \
+                             " -DUSE_BALTIMORE_CERT"
+            elif PACKAGE_PATH == ESP32_PACKAGE_PATH:
+                append_str = " -DDONT_USE_UPLOADTOBLOB"
+            get_update = update_line_file(
+                    platform_txt_file, "build.extra_flags=",
+                    str_append=append_str)
+            print(f"Updated: {get_update} for {platform_txt_file}")
+        else:
+            print(f"Could not find {platform_txt_file}")
+            sys.exit(1)
+
+
+main()

--- a/build_all/base-libraries/AzureIoTHub/src/scripts/automate_board_config.py
+++ b/build_all/base-libraries/AzureIoTHub/src/scripts/automate_board_config.py
@@ -166,21 +166,22 @@ def main():
           f" {ARDUINO_PACKAGES_PATH}")
 
     # Check for and change other versions if they exist
+    BOARD_PATH = Path(ARDUINO_PACKAGES_PATH / PACKAGE_PATH)
     try:
         versions = []
-        with os.scandir(
-                ARDUINO_PACKAGES_PATH / PACKAGE_PATH) as entries:
+        with os.scandir(BOARD_PATH) as entries:
             for version in entries:
                 # avoid files and hidden files
                 if version.is_dir and not version.name.startswith('.'):
                     versions.append(
-                        Path(
-                            ARDUINO_PACKAGES_PATH /
-                            PACKAGE_PATH / version))
+                        Path(BOARD_PATH / version))
     except FileNotFoundError:
         print(
             f'Error: Board files for ESP{board_to_update} not found!\n'
-            f'Please ensure that the board library is installed')
+            f'Directory searched was: {BOARD_PATH}\n'
+            f'Please ensure that the board library exists at the location'
+            f', or check command line parameters to specify a'
+            f' custom Arduino packages path')
         sys.exit(1)
 
     for path in versions:

--- a/build_all/base-libraries/AzureIoTHub/src/scripts/automate_board_config.py
+++ b/build_all/base-libraries/AzureIoTHub/src/scripts/automate_board_config.py
@@ -120,7 +120,7 @@ def main():
     if sys.platform == "darwin":
         ARDUINO_PACKAGES_PATH = Path(Path.home() / "Library/Arduino15")
     elif sys.platform == "linux":
-        ARDUINO_PACKAGES_PATH = Path(Path.home() / ".arduino15/packages/")
+        ARDUINO_PACKAGES_PATH = Path(Path.home() / ".arduino15")
     elif sys.platform == "win32":
         ARDUINO_PACKAGES_PATH = Path(Path.home() / "AppData/Local/Arduino15")
     else:

--- a/build_all/base-libraries/AzureIoTHub/src/scripts/automate_board_config.py
+++ b/build_all/base-libraries/AzureIoTHub/src/scripts/automate_board_config.py
@@ -175,6 +175,8 @@ def main():
                 if version.is_dir and not version.name.startswith('.'):
                     versions.append(
                         Path(BOARD_PATH / version))
+        if len(versions) == 0:
+            raise FileNotFoundError
     except FileNotFoundError:
         print(
             f'Error: Board files for ESP{board_to_update} not found!\n'


### PR DESCRIPTION
My friend @cheejen93 and I wrote an automation script to help make the process of setting up ESP8266 / ESP32 on Azure IoT Hub easier.

Personally it was not the easiest thing for me to setup this azure-iot-arduino lib manually, as it requires editing a platform.txt and possibly the Arduino.h files several directories deep for each applicable board. It’s useful for me to write a script with my friend to automate this process, since we have about forty or so others in our cohort who we’re hoping will connect their Arduinos to our IoT network on Azure. This script can also be run when board libraries get updated, as I know I was scratching my head as to why code wouldn't upload after updating the Arduino board libraries for ESP8266 or ESP32.

Please feel free to let me know what your thoughts are on this script! We tried to make it as simple and easy to use as possible. It features the following:

- Uses built-in libraries for Python 3
- Configures ESP32 and ESP8266 appropriately
    - Does not delete any lines. Only appends necessary flags to the matching line or comments it out depending on the file
- Does its best to ensure data protection:
    - Creates a backup before and during file modification to ensure no data loss
    - Post-script backup file allows for restoring if necessary
    - Prompts to confirm if the user wants to overwrite their backup if it already exists
- Tested on Windows and macOS. Would welcome testing on Linux! 

Testing this is easy. You can go to Arduino, update to a different version or reinstall the ESP8266 / ESP32 board from the Boards Manager and then run the script to ensure that appropriate changes are made.

I've updated the README for this script appropriately and hope it can be of use to some. Please let me know what improvements can be made and I will be happy to maintain this script as possible.