### PR TITLE
Use a supported UART speed for the ESP32

### DIFF
--- a/build_all/base-libraries/AzureIoTUtility/src/esp32/sample_init.cpp
+++ b/build_all/base-libraries/AzureIoTUtility/src/esp32/sample_init.cpp
@@ -16,7 +16,7 @@
 
 static void initSerial() {
     // Start serial and initialize stdout
-    Serial.begin(1000000);
+    Serial.begin(921600);
     Serial.setDebugOutput(true);
 }
 


### PR DESCRIPTION
Some (many?) ESP32 devices only support 1Mbps which is actually 921600bps, not 1000000bps.