### PR TITLE
Fixing ESP8266/BearSSL hostname validaiton.

### DIFF
--- a/pal/inc/sslClient_arduino.h
+++ b/pal/inc/sslClient_arduino.h
@@ -17,7 +17,7 @@ extern "C" {
 
 MOCKABLE_FUNCTION(, void, sslClient_setTimeout, unsigned long, timeout);
 MOCKABLE_FUNCTION(, uint8_t, sslClient_connected);
-MOCKABLE_FUNCTION(, int, sslClient_connect, uint32_t, ipAddress, uint16_t, port);
+MOCKABLE_FUNCTION(, int, sslClient_connect, const char*, name, uint16_t, port);
 MOCKABLE_FUNCTION(, void, sslClient_stop);
 MOCKABLE_FUNCTION(, size_t, sslClient_write, const uint8_t*, buf, size_t, size);
 MOCKABLE_FUNCTION(, size_t, sslClient_print, const char*, str);

--- a/pal/src/sslClient_arduino.cpp
+++ b/pal/src/sslClient_arduino.cpp
@@ -31,13 +31,12 @@ uint8_t sslClient_connected(void)
     return (uint8_t)sslClient.connected();
 }
 
-int sslClient_connect(uint32_t ipAddress, uint16_t port)
+int sslClient_connect(const char* name, uint16_t port)
 {
 #ifdef ARDUINO_ARCH_ESP8266
     sslClient.setTrustAnchors(&cert);
 #endif
-    IPAddress ip = IPAddress(ipAddress);
-    return (int)sslClient.connect(ip, port);
+    return (int)sslClient.connect(name, port);
 }
 
 void sslClient_stop(void)


### PR DESCRIPTION
Tracked by [CVE-2020-17002](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2020-17002)

Fixing ESP8266/tlsio_arduino/BearSSL TLS hostname validation.