### PR TITLE
Adding support for Seeed Wio Terminal

### DIFF
--- a/build_all/base-libraries/AzureIoTSocket_WiFi/src/AzureIoTSocket_WiFi.h
+++ b/build_all/base-libraries/AzureIoTSocket_WiFi/src/AzureIoTSocket_WiFi.h
@@ -10,6 +10,8 @@
 #include <ESP8266WiFi.h>
 #elif ARDUINO_ARCH_ESP32
 #include <WiFi.h>
+#elif WIO_TERMINAL
+#include <WiFi.h>
 #else
 #include <WiFi101.h>
 #endif

--- a/build_all/base-libraries/AzureIoTUtility/src/samd/NTPClientAz.cpp
+++ b/build_all/base-libraries/AzureIoTUtility/src/samd/NTPClientAz.cpp
@@ -58,7 +58,13 @@ void NTPClientAz::prepareRequest()
 void NTPClientAz::sendRequest(const char* host, int port)
 {
     _udp.beginPacket(host, port);
+
+#if WIO_TERMINAL
+    _udp.write((const uint8_t*)_buffer, NTP_PACKET_SIZE);
+#else
     _udp.write(_buffer, NTP_PACKET_SIZE);
+#endif
+
     _udp.endPacket();
 }
 

--- a/build_all/base-libraries/AzureIoTUtility/src/samd/NTPClientAz.h
+++ b/build_all/base-libraries/AzureIoTUtility/src/samd/NTPClientAz.h
@@ -6,7 +6,12 @@
 #ifndef NTPCLIENT_AZ_H
 #define NTPCLIENT_AZ_H
 
+#if WIO_TERMINAL
+#include <WiFi.h>
+#else
 #include <WiFi101.h>
+#endif
+
 #include <WiFiUdp.h>
 
 #define NTP_PACKET_SIZE     48

--- a/build_all/base-libraries/AzureIoTUtility/src/samd/sample_init.cpp
+++ b/build_all/base-libraries/AzureIoTUtility/src/samd/sample_init.cpp
@@ -9,7 +9,16 @@
 #include <time.h>
 #include <sys/time.h>
 #include <SPI.h>
+
+#if WIO_TERMINAL
+#include <WiFi.h>
+#include "WiFiClientSecure.h"
+static WiFiClientSecure sslClient; // for Wio Terminal variant of SAMD
+#else
 #include <WiFi101.h>
+static WiFiSSLClient sslClient;
+#endif
+
 #include <WiFiUdp.h>
 #include "NTPClientAz.h"
 
@@ -79,7 +88,15 @@ static void initTime() {
             delay(2000);
         } else {
             Serial.print("Fetched NTP epoch time is: ");
+
+#if WIO_TERMINAL
+            char buff[32];
+            sprintf(buff, "%.f", difftime(epochTime, (time_t) 0));
+            Serial.println(buff);
+#else
             Serial.println(epochTime);
+#endif
+
             break;
         }
     }

--- a/build_all/base-libraries/AzureIoTUtility/src/samd/time.cpp
+++ b/build_all/base-libraries/AzureIoTUtility/src/samd/time.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if defined(ARDUINO_ARCH_SAMD)
+#if defined(ARDUINO_ARCH_SAMD) && !defined(WIO_TERMINAL)
 #include <time.h>
 #include <sys/time.h>
 

--- a/pal/AzureIoTSocket_WiFi/socketio_esp32wifi.cpp
+++ b/pal/AzureIoTSocket_WiFi/socketio_esp32wifi.cpp
@@ -6,6 +6,8 @@
 #include "ESP8266WiFi.h"
 #elif ARDUINO_ARCH_ESP32
 #include "WiFi.h"
+#elif WIO_TERMINAL
+#include <WiFi.h>
 #else
 #include "WiFi101.h"
 #endif

--- a/pal/src/sslClient_arduino.cpp
+++ b/pal/src/sslClient_arduino.cpp
@@ -15,6 +15,10 @@ static BearSSL::X509List cert(certificates);
 #include "WiFi.h"
 #include "WiFiClientSecure.h"
 static WiFiClientSecure sslClient; // for ESP32
+#elif WIO_TERMINAL
+#include "WiFi.h"
+#include "WiFiClientSecure.h"
+static WiFiClientSecure sslClient; // for Wio Terminal variant of SAMD
 #else
 #include "WiFi101.h"
 #include "WiFiSSLClient.h"


### PR DESCRIPTION
These changes add support for the [Seeed Studios Wio Terminal](https://www.seeedstudio.com/Wio-Terminal-p-4509.html), a new board that is getting strong Microsoft support.

This board is based off the ATSAMD51 core, but has different headers to those expected in this code for SAMD support.

This change fixes #27.